### PR TITLE
Need to check for file syntax before allowing completions

### DIFF
--- a/pgcli_sublime.py
+++ b/pgcli_sublime.py
@@ -100,7 +100,7 @@ class PgcliPlugin(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
 
-        if not get(view, 'pgcli_autocomplete') and not is_sql(view):
+        if not get(view, 'pgcli_autocomplete') or not is_sql(view):
             return []
 
         logger.debug('Searching for completions')

--- a/pgcli_sublime.py
+++ b/pgcli_sublime.py
@@ -100,7 +100,7 @@ class PgcliPlugin(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
 
-        if not get(view, 'pgcli_autocomplete'):
+        if not get(view, 'pgcli_autocomplete') and not is_sql(view):
             return []
 
         logger.debug('Searching for completions')


### PR DESCRIPTION
We need to check for file syntax otherwise sql autocompletions are working in non sql files also. This sometimes slows the whole completions process and result in bad experience.
