### PR TITLE
Fixed column autocompletion and non selected current query execution

### DIFF
--- a/pgcli_sublime.py
+++ b/pgcli_sublime.py
@@ -272,12 +272,10 @@ def get_current_query(view):
     text = get_entire_view_text(view)
     cursor_pos = view.sel()[0].begin()
 
-    # remove new lines count from current position
-    newlines_count = len(text[:cursor_pos].split('\n')) - 1
-    cursor_pos = cursor_pos - newlines_count
-
     # Parse sql
-    split_sql = sqlparse.split(text)
+    stack = sqlparse.engine.FilterStack()
+    stack.split_statements = True
+    split_sql = [str(stmt) for stmt in stack.run(text)]
     cum_len = 0
 
     for query in split_sql:


### PR DESCRIPTION
Column autocompletion was not working due to multiple queries in the View so had to use your implementation of current query execution. Also fixed bug in current query execution because of count not matching due to new lines (\n) between queries.

This needs to be tested on windows because new lines may also include \r between queries on windows.
