### PR TITLE
Add a command for doing \d+ on the selected table

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -26,5 +26,9 @@
     {
 	    "keys":     ["ctrl+alt+shift+c"],
 	    "command":  "pgcli_switch_connection_string"
+	},
+	{
+	    "keys":     ["f1"],
+	    "command": "pgcli_describe_table"
 	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -26,5 +26,9 @@
     {
 	    "keys":     ["ctrl+alt+shift+c"],
 	    "command":  "pgcli_switch_connection_string"
+	},
+	{
+	    "keys":     ["f1"],
+	    "command": "pgcli_describe_table"
 	}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -26,5 +26,9 @@
     {
 	    "keys":     ["ctrl+alt+shift+c"],
 	    "command":  "pgcli_switch_connection_string"
+	},
+	{
+	    "keys":     ["f1"],
+	    "command": "pgcli_describe_table"
 	}
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -13,7 +13,8 @@
                     {"command": "pgcli_show_output_panel"},
                     {"command": "pgcli_open_cli"},
                     {"command": "pgcli_new_sublime_repl"},
-                    {"command": "pgcli_new_sql_file"}
+                    {"command": "pgcli_new_sql_file"},
+                    {"command": "pgcli_describe_table"}
                 ]
             }
         ]


### PR DESCRIPTION
The table name can be either selected or just have the cursor placed in it. It also works with multiple selections/cursors.
I had to do a tiny bit of restructuring to be able to append multiple results when looking up multiple tables (when using multiple cursors).
