### PR TITLE
Add setting for excluding files from autocompletion

### DIFF
--- a/PgcliSublime.sublime_settings
+++ b/PgcliSublime.sublime_settings
@@ -4,19 +4,19 @@
 
 	// Use pgcli to for autocomplete? If false, standard sublime autocompletion is used
 	"pgcli_autocomplete": 			true,
-	
+
 	// List of python directories to add to python path so pgcli can be imported
 	"pgcli_dirs": 					[],
-	
+
 	// List of python site directories to add to python path so pgcli can be imported
 	"pgcli_site_dirs": 				[],
-	
+
 	// The path to the postgresql database. This may also be overridden in project-specific settings
 	"pgcli_url": 					"postgresql://",
 
 	// List of urls to show in the quick-connect menu
 	"pgcli_urls": 					[],
-	
+
 	// Save query to file on run?
 	// 		"always": always save; "never" never save; "success" save if no errors
 	"pgcli_save_on_run_query_mode": "success",
@@ -24,14 +24,16 @@
 	// The command to send to os.system to open a pgcli command prompt
 	// {url} is automatically formatted with the appropriate database url
 	"pgcli_system_cmd":             "pgcli {url}",
-	
+
 	// Controls log level of PgcliSublime logger
 	"pgcli_sublime_log_level": 		"WARNING",
-	
+
 	// Controls log level of pgcli
 	"pgcli_log_level": 				"WARNING",
-	
-	// Controls the console handler
-	"pgcli_console_log_level":      "WARNING"
 
+	// Controls the console handler
+	"pgcli_console_log_level":      "WARNING",
+
+	// Regexes for file paths to exclude from autocompletion
+	"autocomplete_exclusions": [],
 }

--- a/pgcli_sublime.py
+++ b/pgcli_sublime.py
@@ -101,7 +101,11 @@ class PgcliPlugin(sublime_plugin.EventListener):
         sublime.set_timeout_async(lambda: check_pgcli(view), 0)
 
     def on_query_completions(self, view, prefix, locations):
-
+        autocomplete_exclusions = settings.get('autocomplete_exclusions')
+        for pattern in settings.get('autocomplete_exclusions'):
+            if view.file_name() and re.match(pattern, view.file_name()):
+                logger.debug('File excluded from autocompletion')
+                return
         if not get(view, 'pgcli_autocomplete') or not is_sql(view):
             return []
 


### PR DESCRIPTION
I've had a problem with Sublime freezing for a long time when editing a certain .sql file (a file containing the thousands of \i commands needed to rebuild the database in question). The length of the file does not appear to be the deciding factor, which is why I made this an exclusion list rather than a max-file-length-for-autocompletion setting.
